### PR TITLE
feature / clean ws connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ import { WseServer } from 'wse'
 // auth handler
 function identify ({ payload, resolve, meta }) {
   if (payload === SECRET) {
-    const user_id = 'any user id here'
-    resolve(user_id, { hey: 'welcome back!' })
+    const cid = 'any user id here'
+    resolve(cid, { hey: 'welcome back!' })
   } else {
     resolve(false)
   }
@@ -36,7 +36,7 @@ const server = new WseServer({ port: 4200, identify })
 server.broadcast('broad-message', { paylog: 'hey there!' })
 
 server.channel.on('test-message', (conn, dat) => {
-  console.log('we got test-message from', conn.client.id, dat)
+  console.log('we got test-message from', conn.cid, dat)
 
   conn.send('welcome-here', { payload: 42 })
 })

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ const server = new WseServer({ port: 4200, identify })
 
 server.broadcast('broad-message', { paylog: 'hey there!' })
 
-server.channel.on('test-message', (client, dat) => {
-  console.log('we got test-message from', client.id, dat)
+server.channel.on('test-message', (conn, dat) => {
+  console.log('we got test-message from', conn.client.id, dat)
 
-  client.send('welcome-here', { payload: 42 })
+  conn.send('welcome-here', { payload: 42 })
 })
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "wse",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "ISC",
       "dependencies": {
         "a-signal": "^2.1.1",

--- a/src/client.js
+++ b/src/client.js
@@ -10,7 +10,7 @@ export class WseClient {
     this.url = url
     this.ws_options = ws_options
     this.reused = 0
-    this.timeout = tO
+    this.tO = tO
 
     this.channel = new EE()
 
@@ -62,8 +62,8 @@ export class WseClient {
       }
       this._ws.onerror = (err) => this.error.emit(new WseError(WSE_CLIENT_ERRORS.WS_ERROR, { raw: err }))
       this._ws.onclose = (event) => {
-        reject(String(event.reason))
         this.closed.emit(event.code, String(event.reason))
+        reject(String(event.reason))
       }
     })
   }
@@ -97,34 +97,47 @@ export class WseClient {
    * Send RP request to the server.
    * @param rp - name of RP
    * @param [payload] - payload
-   * @param [tO] - timeout
    * @returns {Promise<*>}
    */
-  async call (rp, payload, tO = this.timeout) {
+  async call (rp, payload) {
     if (!rp || typeof rp !== 'string') throw new Error('rp_name not a string')
     if (this._ws && this._ws.readyState === WS.OPEN) {
       return new Promise((resolve, reject) => {
         const stamp = [ this.protocol.internal_types.call, rp, make_stamp() ].join(':')
+
+        let timeout
+
         const handler = (payload) => {
           if (payload.result) {
+            if (timeout) clearTimeout(timeout)
+            closedBind.off()
             resolve(payload.result)
           } else {
             let err_code = WSE_CLIENT_ERRORS.RP_RESPONSE_ERR
             if (payload.error && payload.error.code) {
               if (payload.error.code === WSE_SERVER_ERR.RP_NOT_REGISTERED) err_code = WSE_CLIENT_ERRORS.RP_NOT_EXISTS
-              if (payload.error.code === WSE_SERVER_ERR.FAILED_TO_EXECUTE_RP) err_code = WSE_CLIENT_ERRORS.RP_FAILED
+              if (payload.error.code === WSE_SERVER_ERR.RP_EXECUTION_FAILED) err_code = WSE_CLIENT_ERRORS.RP_FAILED
             }
-            return reject(new WseError(err_code))
+            return rejection(err_code, payload)
           }
         }
 
+        const rejection = (err_code, details) => {
+          if (timeout) clearTimeout(timeout)
+          this.channel.off(stamp, handler)
+          return reject(new WseError(err_code, details))
+        }
+
+        const closedBind = this.closed.once((code, reason) => {
+          rejection(WSE_CLIENT_ERRORS.RP_DISCONNECT, { code, reason })
+        })
+
         this.channel.once(stamp, handler)
 
-        if (tO > 0) {
-          setTimeout(() => {
-            this.channel.off(stamp, handler)
-            reject(new WseError(WSE_CLIENT_ERRORS.RP_TIMEOUT))
-          }, tO * 1000)
+        if (this.tO > 0) {
+          timeout = setTimeout(() => {
+            return rejection(WSE_CLIENT_ERRORS.RP_TIMEOUT)
+          }, this.tO * 1000)
         }
 
         // todo: should we pass tO to the server?

--- a/src/client.js
+++ b/src/client.js
@@ -43,8 +43,6 @@ export class WseClient {
         this.connected.emit(identity, meta)
       }
       this._ws.onmessage = (message) => {
-
-
         let [ type, payload ] = this.protocol.unpack(message.data)
         if (type === this.protocol.internal_types.challenge) {
           if (typeof this.challenge_solver === 'function') {
@@ -80,7 +78,6 @@ export class WseClient {
 
   _process_msg (message) {
     let [ type, payload ] = this.protocol.unpack(message.data)
-
     return this.channel.emit(type, payload) || this.ignored.emit(type, payload)
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -43,8 +43,9 @@ export class WseClient {
         this.connected.emit(identity, meta)
       }
       this._ws.onmessage = (message) => {
-        let [ type, payload ] = this.protocol.unpack(message.data)
 
+
+        let [ type, payload ] = this.protocol.unpack(message.data)
         if (type === this.protocol.internal_types.challenge) {
           if (typeof this.challenge_solver === 'function') {
             this.challenge_solver(payload, (solution) => {
@@ -57,7 +58,9 @@ export class WseClient {
           this.ready.emit(payload)
           resolve(payload)
         }
-        this._ws.onmessage = (message) => { this._process_msg(message) }
+        this._ws.onmessage = (message) => {
+          this._process_msg(message)
+        }
       }
       this._ws.onerror = (err) => this.error.emit(new WseError(WSE_CLIENT_ERRORS.WS_ERROR, { raw: err }))
       this._ws.onclose = (event) => {
@@ -77,6 +80,7 @@ export class WseClient {
 
   _process_msg (message) {
     let [ type, payload ] = this.protocol.unpack(message.data)
+
     return this.channel.emit(type, payload) || this.ignored.emit(type, payload)
   }
 

--- a/src/common.js
+++ b/src/common.js
@@ -9,23 +9,24 @@ export const WSE_REASON = Object.freeze({
 export const WSE_CLIENT_ERRORS = Object.freeze({
   CONNECTION_NOT_OPENED: 'wse.client.not-opened',
   INVALID_CRA_HANDLER: 'wse.client.invalid-cra-handler',
-  RP_TIMEOUT: 'wse.client.rp-timeout',
-  RP_NOT_EXISTS: 'wse.client.rp-not-exists',
-  RP_FAILED: 'wse.client.rp-failed',
-  RP_RESPONSE_ERR: 'wse.client.rp-response-error',
+  RP_TIMEOUT: 'wse.client.rp.timeout',
+  RP_NOT_EXISTS: 'wse.client.rp.not-exists',
+  RP_FAILED: 'wse.client.rp.failed',
+  RP_RESPONSE_ERR: 'wse.client.rp.response-error',
+  RP_DISCONNECT: 'wse.client.rp.disconnect',
   WS_ERROR: 'wse.client.ws-error',
 })
 
 export const WSE_SERVER_ERR = Object.freeze({
-  NO_CLIENT_CONNECTION: 'wse-server.client.connection-missing',
-  IDENTIFY_HANDLER_MISSING: 'wse-server.auth.identify-handler-missing',
-  INVALID_CRA_GENERATOR: 'wse-server.auth.invalid-cra-generator',
-  FAILED_TO_EXECUTE_RP: 'wse-server.rp.failed',
-  RP_NOT_REGISTERED: 'wse-server.rp.not-registered',
-  RP_ALREADY_REGISTERED: 'wse-server.rp.already-registered',
-  PROTOCOL_VIOLATION: 'wse-server.protocol-violation',
-  CONNECTION_ERROR: 'wse-server.connection-error',
-  MESSAGE_PROCESSING_ERROR: 'wse-server.msg-processing-error',
+  NO_CLIENT_CONNECTION: 'wse.server.client.connection-missing',
+  IDENTIFY_HANDLER_MISSING: 'wse.server.auth.identify-handler-missing',
+  INVALID_CRA_GENERATOR: 'wse.server.auth.invalid-cra-generator',
+  RP_EXECUTION_FAILED: 'wse.server.rp.failed',
+  RP_NOT_REGISTERED: 'wse.server.rp.not-registered',
+  RP_ALREADY_REGISTERED: 'wse.server.rp.already-registered',
+  PROTOCOL_VIOLATION: 'wse.server.protocol-violation',
+  CONNECTION_ERROR: 'wse.server.connection-error',
+  MESSAGE_PROCESSING_ERROR: 'wse.server.msg-processing-error',
 })
 
 

--- a/src/server.js
+++ b/src/server.js
@@ -10,13 +10,46 @@ const CLIENT_VALIDATING = 'CLIENT_VALIDATING'
 const CLIENT_CHALLENGED = 'CLIENT_CHALLENGED'
 const CLIENT_VALID = 'CLIENT_VALID'
 
-const _identity = Symbol('_identity')
-const _meta = Symbol('_meta')
-const _challenge_quest = Symbol('_challenge_quest')
-const _challenge_response = Symbol('_challenge_response')
-const _client_id = Symbol('_client_id')
-const _valid_stat = Symbol('_valid_stat')
-const _id = Symbol('id')
+class WseConnection {
+  /**
+   *
+   * @param {WebSocket} ws_conn
+   * @param {WseServer} server
+   */
+  constructor (ws_conn, server) {
+    this.identity = null
+    this.meta = {}
+    this.challenge_quest = null
+    this.challenge_response = null
+    this.client_id = ''
+    this.valid_stat = CLIENT_STRANGER
+    this.cid = ''
+
+    this.remote_addr = ''
+
+    Object.defineProperty(this, 'client', { enumerable: false, value: null, writable: true })
+    Object.defineProperty(this, 'ws_conn', { enumerable: false, value: ws_conn })
+    Object.defineProperty(this, 'server', { enumerable: false, value: server })
+  }
+
+  /**
+   * @param {WseIdentity} client
+   */
+  _identify_as (client) {
+    this.client = client
+    this.client_id = client.id
+    this.valid_stat = CLIENT_VALID
+    this.cid = make_stamp(15)
+  }
+
+  send (type, payload, stamp) {
+    this.ws_conn.send(this.server.protocol.pack({ type, payload, stamp }))
+  }
+
+  get readyState () {
+    return this.ws_conn.readyState
+  }
+}
 
 
 export class WseServer {
@@ -128,19 +161,22 @@ export class WseServer {
     Object.assign(this.options, options)
 
     this.ws = new WebSocketServer({ ...this.options, handleProtocols: (a) => this.protocol.name })
-    this.ws.on('connection', (conn, req) => {
+    this.ws.on('connection', (ws_conn, req) => {
+      const conn = new WseConnection(ws_conn, this)
+
       this._handle_connection(conn, req)
 
-      conn.on('message', (message) => {
-        if (conn[_valid_stat] === CLIENT_VALIDATING) return
+      conn.ws_conn.on('message', (message) => {
+        if (conn.valid_stat === CLIENT_VALIDATING) return
 
         let type
         let payload
         let stamp
+
         try {
           [ type, payload, stamp ] = this.protocol.unpack(message)
 
-          switch (conn[_valid_stat]) {
+          switch (conn.valid_stat) {
             case CLIENT_VALID:
               if (stamp) {
                 return this._handle_valid_call(conn, type, payload, stamp)
@@ -149,6 +185,7 @@ export class WseServer {
               } else {
                 throw new WseError(WSE_SERVER_ERR.PROTOCOL_VIOLATION, { type, payload, stamp })
               }
+
             case CLIENT_STRANGER:
             case CLIENT_CHALLENGED:
               return this._handle_stranger_message(conn, type, payload)
@@ -157,27 +194,27 @@ export class WseServer {
           const error = err.type !== 'wse-error'
               ? new WseError(WSE_SERVER_ERR.MESSAGE_PROCESSING_ERROR, { raw: err })
               : err
-          error.message_from = conn[_client_id] ? `${ conn[_client_id] }#${ conn[_id] }` : 'stranger'
+          error.message_from = conn.client_id ? `${ conn.client_id }#${ conn.cid }` : 'stranger'
           this.error.emit(err, conn)
-          if (conn[_client_id] && this.clients.has(conn[_client_id])) {
-            this.clients.get(conn[_client_id])._conn_drop(conn[_id], WSE_REASON.PROTOCOL_ERR)
+          if (conn.client_id && this.clients.has(conn.client_id)) {
+            this.clients.get(conn.client_id)._conn_drop(conn.cid, WSE_REASON.PROTOCOL_ERR)
           } else {
-            conn.removeAllListeners()
-            conn.close(1000, WSE_REASON.PROTOCOL_ERR)
+            conn.ws_conn.removeAllListeners()
+            conn.ws_conn.close(1000, WSE_REASON.PROTOCOL_ERR)
           }
         }
       })
 
-      conn.on('close', (code, reason) => {
-        if (conn[_client_id] && this.clients.has(conn[_client_id])) {
-          const client = this.clients.get(conn[_client_id])
-          client._conn_drop(conn[_id])
+      conn.ws_conn.on('close', (code, reason) => {
+        if (conn.client_id && this.clients.has(conn.client_id)) {
+          const client = this.clients.get(conn.client_id)
+          client._conn_drop(conn.cid)
         } else {
           this.disconnected.emit(conn, code, reason)
         }
       })
 
-      conn.onerror = (e) => this.error.emit(new WseError(WSE_SERVER_ERR.CONNECTION_ERROR, { raw: e }), conn)
+      conn.ws_conn.onerror = (e) => this.error.emit(new WseError(WSE_SERVER_ERR.CONNECTION_ERROR, { raw: e }), conn)
     })
   }
 
@@ -194,64 +231,53 @@ export class WseServer {
   }
 
   _handle_connection (conn, req) {
-    if (conn.protocol !== this.protocol.name) {
-      return conn.close(1000, WSE_REASON.PROTOCOL_ERR)
+    if (conn.ws_conn.protocol !== this.protocol.name) {
+      return conn.ws_conn.close(1000, WSE_REASON.PROTOCOL_ERR)
     }
-
-    conn[_client_id] = null
-    conn[_valid_stat] = CLIENT_STRANGER
-    conn[_meta] = {}
-    conn[_id] = '' // todo: uuid?
 
     // RESOLVING IPV4 REMOTE ADDR
     conn.remote_addr = req.headers['x-forwarded-for'] || req.connection.remoteAddress
     if (conn.remote_addr.substr(0, 7) === '::ffff:') conn.remote_addr = conn.remote_addr.substr(7)
-
-    // todo: should be able to override by meta
-    conn.pub_host = conn.remote_addr
   }
 
   _handle_valid_message (conn, type, payload) {
-    const client = this.clients.get(conn[_client_id])
-    this.channel.emit(type, client, payload, conn[_id]) || this.ignored.emit(client, type, payload, conn[_id])
+    this.channel.emit(type, conn, payload) || this.ignored.emit(conn, type, payload)
   }
 
   _handle_valid_call (conn, type, payload, stamp) {
-    const client = this.clients.get(conn[_client_id])
     const reply = {}
-    
     if (this._rps.has(type)) {
       const rp = this._rps.get(type)
 
       const rp_wrap = async () => {
-        reply.result = await rp(client, payload, conn[_id])
-        client.send(stamp, reply, conn[_id])
+        reply.result = await rp(conn, payload)
+        conn.send(stamp, reply)
       }
 
       rp_wrap().catch(err => {
         reply.error = { code: WSE_SERVER_ERR.FAILED_TO_EXECUTE_RP }
-        client.send(stamp, reply, conn[_id])
+        conn.send(stamp, reply)
 
         this.error.emit(new WseError(WSE_SERVER_ERR.FAILED_TO_EXECUTE_RP, {
           type,
           payload,
           stamp,
-          client_id: client.id,
-          conn_id: conn[_id],
+          client_id: conn.id,
+          cid: conn.cid,
           raw: err,
         }), conn)
       })
 
     } else {
       reply.error = { code: WSE_SERVER_ERR.RP_NOT_REGISTERED }
-      client.send(stamp, reply, conn[_id])
+      conn.send(stamp, reply)
 
       this.error.emit(new WseError(WSE_SERVER_ERR.RP_NOT_REGISTERED, {
         type,
         payload,
         stamp,
-        client_id: client.id,
-        conn_id: conn[_id],
+        client_id: conn.client_id,
+        cid: conn.cid,
       }), conn)
     }
   }
@@ -276,32 +302,32 @@ export class WseServer {
   }
 
   _handle_stranger_message (conn, type, payload) {
-    if (conn[_valid_stat] === CLIENT_STRANGER) {
+    if (conn.valid_stat === CLIENT_STRANGER) {
       if (type === this.protocol.internal_types.hi) {
-        conn[_valid_stat] = CLIENT_VALIDATING
-        conn[_identity] = payload.identity
+        conn.valid_stat = CLIENT_VALIDATING
+        conn.identity = payload.identity
 
-        Object.assign(conn[_meta], payload.meta || {})
+        Object.assign(conn.meta, payload.meta || {})
 
         if (typeof this.cra_generator === 'function') {
-          this.cra_generator(conn[_identity], conn[_meta], (quest) => {
-            conn[_challenge_quest] = quest
-            conn.send(this.protocol.pack({ type: this.protocol.internal_types.challenge, payload: quest }))
-            conn[_valid_stat] = CLIENT_CHALLENGED
+          this.cra_generator(conn.identity, conn.meta, (quest) => {
+            conn.challenge_quest = quest
+            conn.send(this.protocol.internal_types.challenge, quest)
+            conn.valid_stat = CLIENT_CHALLENGED
           })
           return
         }
       } else {
-        conn.close(1000, WSE_REASON.PROTOCOL_ERR)
+        conn.ws_conn.close(1000, WSE_REASON.PROTOCOL_ERR)
         return
       }
     }
 
-    if (conn[_valid_stat] === CLIENT_CHALLENGED) {
+    if (conn.valid_stat === CLIENT_CHALLENGED) {
       if (type === this.protocol.internal_types.challenge) {
-        conn[_challenge_response] = payload
+        conn.challenge_response = payload
       } else {
-        conn.close(1000, WSE_REASON.PROTOCOL_ERR)
+        conn.ws_conn.close(1000, WSE_REASON.PROTOCOL_ERR)
       }
     }
 
@@ -310,38 +336,45 @@ export class WseServer {
     }
 
     this.identify({
-      identity: conn[_identity],
-      meta: conn[_meta],
+      identity: conn.identity,
+      meta: conn.meta,
       resolve,
       challenge: typeof this.cra_generator === 'function'
-          ? { quest: conn[_challenge_quest], response: conn[_challenge_response] }
+          ? { quest: conn.challenge_quest, response: conn.challenge_response }
           : null,
-      id: conn[_id],
+      id: conn.cid,
     })
   }
 
   _identify_connection (conn, client_id, welcome_payload, payload) {
     if (!client_id) {
-      conn.close(1000, WSE_REASON.NOT_AUTHORIZED)
+      conn.ws_conn.close(1000, WSE_REASON.NOT_AUTHORIZED)
       return
     }
 
-    conn[_client_id] = client_id
-    conn[_id] = make_stamp(15)
-    conn[_valid_stat] = CLIENT_VALID
+    let wasNewIdentity = false
 
-    let client = this.clients.get(conn[_client_id])
+    let client = this.clients.get(client_id)
 
-    if (client) {
-      client._conn_add(conn)
-      client.send(this.protocol.internal_types.welcome, welcome_payload, conn[_id])
+    if (!client) {
+      wasNewIdentity = true
+      client = new WseIdentity({
+        identity: conn.identity,
+        meta: conn.meta,
+        id: client_id,
+      }, this)
+      this.clients.set(client_id, client)
+    }
+
+    client._conn_add(conn)
+
+    conn.send(this.protocol.internal_types.welcome, welcome_payload)
+
+    if (wasNewIdentity) {
+      this.joined.emit(client, payload.meta || {})
       this.connected.emit(conn)
     } else {
-      const client = new WseClient(this, conn)
-      this.clients.set(client.id, client)
-      client.send(this.protocol.internal_types.welcome, welcome_payload)
       this.connected.emit(conn)
-      this.joined.emit(client, payload.meta || {})
     }
   }
 
@@ -381,29 +414,33 @@ export class WseServer {
    */
   send (client_id, type, payload, conn_id) {
     const client = this.clients.get(client_id)
-    if (client) client.send(type, payload, conn_id)
+    if (client) {
+      client.send(type, payload, conn_id)
+    }
   }
 }
 
-class WseClient {
+class WseIdentity {
   /**
+   * @param {string} id - client id
+   * @param {*} identity - identity payload
    * @param {WseServer} server - wsm instance
-   * @param {WebSocket} conn - ws connection
    * @param {object} meta - object with user-defined data
    */
-  constructor (server, conn, meta = {}) {
-    this.id = conn[_client_id]
+  constructor ({ id, identity, meta = {} }, server) {
+    this.id = id
     this.conns = new Map()
-    this.srv = server
-    this.meta = conn[_meta]
-    this.identity = conn[_identity]
+    this.meta = meta
+    this.identity = identity
 
-    this._conn_add(conn)
+    Object.defineProperty(this, 'server', { enumerable: false, value: server })
   }
 
   _conn_add (conn) {
-    this.conns.set(conn[_id], conn)
-    if (this.srv.connPerUser < this.conns.size) {
+    conn._identify_as(this)
+
+    this.conns.set(conn.cid, conn)
+    if (this.server.connPerUser < this.conns.size) {
       const key_to_delete = this.conns[Symbol.iterator]().next().value[0]
       this._conn_drop(key_to_delete, WSE_REASON.CLIENTS_CONCURRENCY)
     }
@@ -415,18 +452,18 @@ class WseClient {
 
     if (!conn) throw new WseError(WSE_SERVER_ERR.NO_CLIENT_CONNECTION, { id })
 
-    conn.removeAllListeners()
+    conn.ws_conn.removeAllListeners()
 
     if (conn.readyState === WebSocket.CONNECTING || conn.readyState === WebSocket.OPEN) {
-      conn.close(1000, reason)
+      conn.ws_conn.close(1000, reason)
     }
 
     this.conns.delete(id)
 
-    this.srv.disconnected.emit(conn, 1000, reason)
+    this.server.disconnected.emit(conn, 1000, reason)
 
     if (this.conns.size === 0) {
-      this.srv.dropClient(this.id, reason)
+      this.server.dropClient(this.id, reason)
     }
   }
 
@@ -441,12 +478,12 @@ class WseClient {
     if (conn_id) {
       const conn = this.conns.get(conn_id)
       if (conn.readyState === WebSocket.OPEN) {
-        conn.send(this.srv.protocol.pack({ type, payload }))
+        conn.send( type, payload )
       }
     } else {
       this.conns.forEach(conn => {
         if (conn.readyState === WebSocket.OPEN) {
-          conn.send(this.srv.protocol.pack({ type, payload }))
+          conn.send( type, payload )
         }
       })
     }

--- a/test.js
+++ b/test.js
@@ -20,6 +20,8 @@ import { runner } from 'test-a-bit'
     { script: './tests/invalid-hi-drop.js' },
     { script: './tests/invalid-hi-err.js' },
     { script: './tests/meta.js' },
+    { script: './tests/multiple-servers.js' },
+    { script: './tests/personal-and-all.js' },
     { script: './tests/ready-event.js' },
     { script: './tests/rp-call.js' },
     { script: './tests/rp-not-registered.js' },
@@ -28,6 +30,5 @@ import { runner } from 'test-a-bit'
     { script: './tests/server2client-ignored.js' },
     { script: './tests/swarm-connect.js' },
     { script: './tests/swarm-disconnect.js' },
-    { script: './tests/multiple-servers' },
   ])
 })()

--- a/tests/client2server-ignored.js
+++ b/tests/client2server-ignored.js
@@ -8,7 +8,7 @@ execute('client > server: ignored message', async (success, fail) => {
   const server = new WseServer({ port: WS_PORT, identify })
   const client = new WseClient({ url: WS_URL })
 
-  server.when.ignored((client, type, payload) => {
+  server.when.ignored((conn, type, payload) => {
     payload.value === 42 && type === 'test'
         ? success('ignored message busted')
         : fail('invalid data from client')

--- a/tests/client2server.js
+++ b/tests/client2server.js
@@ -8,7 +8,7 @@ execute('client > server', async (success, fail) => {
   const server = new WseServer({ port: WS_PORT, identify })
   const client = new WseClient({ url: WS_URL })
 
-  server.channel.on('test-message', (client, payload) => {
+  server.channel.on('test-message', (conn, payload) => {
     payload.value === 42
         ? success('client sent message')
         : fail('invalid data from client')

--- a/tests/count-10.js
+++ b/tests/count-10.js
@@ -9,10 +9,10 @@ execute('count together to 10', async (success, fail) => {
   const client = new WseClient({ url: WS_URL })
 
   let server_var = 0
-  server.channel.on('count', (type, payload) => {
+  server.channel.on('count', (conn, payload) => {
     server_var = payload.count
     server_var += 1
-    type.send('count', { count: server_var })
+    conn.send('count', { count: server_var })
   })
 
   let client_var = 0

--- a/tests/count-1001.js
+++ b/tests/count-1001.js
@@ -9,12 +9,12 @@ execute('count together to 1001', async (success, fail) => {
   const client = new WseClient({ url: WS_URL })
 
   let server_var = 0
-  server.channel.on('count', (type, payload) => {
+  server.channel.on('count', (conn, payload) => {
     if (payload.count >= 1001) return success(`${ payload.count }!`)
 
     server_var = payload.count
     server_var += 1
-    type.send('count', { count: server_var })
+    conn.send('count', { count: server_var })
   })
 
   let client_var = 0

--- a/tests/cpu-messages.js
+++ b/tests/cpu-messages.js
@@ -37,9 +37,10 @@ execute('x-cpu messages', async (success, fail) => {
     check_messages()
   })
 
+
   await clientA.connect(SECRET, { user_id: 'UID1' })
   await clientB.connect(SECRET, { user_id: 'UID1' })
   await clientC.connect(SECRET, { user_id: 'UID1' })
 
-  setTimeout(() => server.send('UID1', 'msg', { hey: 'there' }), 100)
+  setTimeout(() => server.send('UID1', 'msg', { hey: 'there' }), 200)
 })

--- a/tests/external-server.js
+++ b/tests/external-server.js
@@ -12,7 +12,7 @@ execute('external httpServer', async (success, fail) => {
   const server = new WseServer({ identify, skipInit: true })
   const client = new WseClient({ url: WS_URL })
 
-  server.channel.on('test-message', (client, payload) => {
+  server.channel.on('test-message', (conn, payload) => {
     payload.value === 42
         ? success('client sent message')
         : fail('invalid data from client')

--- a/tests/multiple-servers.js
+++ b/tests/multiple-servers.js
@@ -53,32 +53,32 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
   })
 
 
-  server1.when.joined((c, meta) => {
-    if (meta.user_id === 1 && c.id === 1) {
+  server1.when.joined((conn, meta) => {
+    if (meta.user_id === 1 && conn.id === 1) {
       markGoal('c1_connect')
     } else {
       fail('invalid meta on join')
     }
   })
 
-  server2.when.joined((c, meta) => {
-    if (meta.user_id === 2 && c.id === 2) {
+  server2.when.joined((conn, meta) => {
+    if (meta.user_id === 2 && conn.id === 2) {
       markGoal('c2_connect')
     } else {
       fail('invalid meta on join')
     }
   })
 
-  server1.channel.on('talk', (c, payload) => {
-    if (c.client_id === 1 && payload === 10) {
+  server1.channel.on('talk', (conn, payload) => {
+    if (conn.client_id === 1 && payload === 10) {
       markGoal('talk1')
     } else {
       fail('got wrong message on server1')
     }
   })
 
-  server2.channel.on('talk', (c, payload) => {
-    if (c.client_id === 2 && payload === 20) {
+  server2.channel.on('talk', (conn, payload) => {
+    if (conn.client_id === 2 && payload === 20) {
       markGoal('talk2')
     } else {
       fail('got wrong message on server2')

--- a/tests/multiple-servers.js
+++ b/tests/multiple-servers.js
@@ -53,16 +53,16 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
   })
 
 
-  server1.when.joined((client, meta) => {
-    if (meta.user_id === 1 && client.id === 1) {
+  server1.when.joined((c, meta) => {
+    if (meta.user_id === 1 && c.id === 1) {
       markGoal('c1_connect')
     } else {
       fail('invalid meta on join')
     }
   })
 
-  server2.when.joined((client, meta) => {
-    if (meta.user_id === 2 && client.id === 2) {
+  server2.when.joined((c, meta) => {
+    if (meta.user_id === 2 && c.id === 2) {
       markGoal('c2_connect')
     } else {
       fail('invalid meta on join')
@@ -70,7 +70,7 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
   })
 
   server1.channel.on('talk', (c, payload) => {
-    if (c.id === 1 && payload === 10) {
+    if (c.client_id === 1 && payload === 10) {
       markGoal('talk1')
     } else {
       fail('got wrong message on server1')
@@ -78,7 +78,7 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
   })
 
   server2.channel.on('talk', (c, payload) => {
-    if (c.id === 2 && payload === 20) {
+    if (c.client_id === 2 && payload === 20) {
       markGoal('talk2')
     } else {
       fail('got wrong message on server2')

--- a/tests/multiple-servers.js
+++ b/tests/multiple-servers.js
@@ -54,7 +54,7 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
 
 
   server1.when.joined((conn, meta) => {
-    if (meta.user_id === 1 && conn.id === 1) {
+    if (meta.user_id === 1 && conn.cid === 1) {
       markGoal('c1_connect')
     } else {
       fail('invalid meta on join')
@@ -62,7 +62,7 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
   })
 
   server2.when.joined((conn, meta) => {
-    if (meta.user_id === 2 && conn.id === 2) {
+    if (meta.user_id === 2 && conn.cid === 2) {
       markGoal('c2_connect')
     } else {
       fail('invalid meta on join')
@@ -70,7 +70,7 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
   })
 
   server1.channel.on('talk', (conn, payload) => {
-    if (conn.client_id === 1 && payload === 10) {
+    if (conn.cid === 1 && payload === 10) {
       markGoal('talk1')
     } else {
       fail('got wrong message on server1')
@@ -78,7 +78,7 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
   })
 
   server2.channel.on('talk', (conn, payload) => {
-    if (conn.client_id === 2 && payload === 20) {
+    if (conn.cid === 2 && payload === 20) {
       markGoal('talk2')
     } else {
       fail('got wrong message on server2')
@@ -86,7 +86,6 @@ execute('multiple servers sharing a single http/s server', async (success, fail)
   })
 
   http.listen(WS_PORT)
-
 
   await client1.connect(SECRET, { user_id: 1 })
   client1.send('talk', 10)

--- a/tests/personal-and-all.js
+++ b/tests/personal-and-all.js
@@ -25,8 +25,8 @@ execute('personal and all-connections', async (success, fail) => {
   client2.channel.on('both', () => { count('both') })
 
   server.channel.on('hey', (conn) => {
-    conn.client.send('both', conn.client.id)
-    conn.send('only', conn.client.id)
+    conn.client.send('both')
+    conn.send('only')
   })
 
   await client1.connect(SECRET, { user_id: 1 })

--- a/tests/personal-and-all.js
+++ b/tests/personal-and-all.js
@@ -1,0 +1,39 @@
+import { execute } from 'test-a-bit'
+
+import { identify, SECRET, WS_PORT, WS_URL } from './_helpers.js'
+import { WseServer }                         from '../src/server.js'
+import { WseClient }                         from '../src/client.js'
+
+execute('personal and all-connections', async (success, fail) => {
+  const server = new WseServer({ port: WS_PORT, identify, connPerUser: 2 })
+
+  const goals = { only1: 0, only2: 0, both: 0 }
+  const expect = { only1: 2, only2: 1, both: 6 }
+
+  const count = (g) => {
+    goals[g]++
+    if (Object.keys(expect).every(k => {
+      return expect[k] === goals[k]
+    })) success('all right')
+  }
+  const client1 = new WseClient({ url: WS_URL })
+  const client2 = new WseClient({ url: WS_URL })
+
+  client1.channel.on('only', () => { count('only1') })
+  client1.channel.on('both', () => { count('both') })
+  client2.channel.on('only', () => { count('only2') })
+  client2.channel.on('both', () => { count('both') })
+
+  server.channel.on('hey', (conn) => {
+    conn.client.send('both', conn.client.id)
+    conn.send('only', conn.client.id)
+  })
+
+  await client1.connect(SECRET, { user_id: 1 })
+  await client2.connect(SECRET, { user_id: 1 })
+
+  client1.send('hey')
+  client1.send('hey')
+
+  client2.send('hey')
+})

--- a/tests/rp-disconnect.js
+++ b/tests/rp-disconnect.js
@@ -1,0 +1,35 @@
+import { execute } from 'test-a-bit'
+
+import { identify, SECRET, wait, WS_PORT, WS_URL } from './_helpers.js'
+import { WSE_CLIENT_ERRORS, WSE_SERVER_ERR }       from '../src/common.js'
+import { WseServer }                               from '../src/server.js'
+import { WseClient }                               from '../src/client.js'
+
+execute('rp timeout', async (success, fail) => {
+  const server = new WseServer({ port: WS_PORT, identify })
+  const client = new WseClient({ url: WS_URL, tO: 3 })
+
+  server.register('test-rp', async (conn, payload) => {
+    conn.drop()
+    await wait(200)
+    return 1
+  })
+
+  await client.connect(SECRET)
+
+  try {
+    await client.call('test-rp', null)
+    client.close()
+    fail('still responds')
+  } catch (e) {
+    if ([
+      WSE_CLIENT_ERRORS.RP_DISCONNECT, // only correct answer for the browser
+      WSE_CLIENT_ERRORS.RP_FAILED, // node (in test)
+      WSE_SERVER_ERR.RP_EXECUTION_FAILED, // node (in test)
+    ].includes(e.code)) {
+      success('mostly correct err: ' + e.code)
+    } else {
+      fail('incorrect error code ' + e.code)
+    }
+  }
+})

--- a/tests/rp-timeout.js
+++ b/tests/rp-timeout.js
@@ -7,7 +7,7 @@ import { WseClient }                               from '../src/client.js'
 
 execute('rp timeout', async (success, fail) => {
   const server = new WseServer({ port: WS_PORT, identify })
-  const client = new WseClient({ url: WS_URL })
+  const client = new WseClient({ url: WS_URL, tO: .1 })
 
   server.register('test-rp', async (client, payload) => {
     await wait(60000)
@@ -17,7 +17,7 @@ execute('rp timeout', async (success, fail) => {
   await client.connect(SECRET)
 
   try {
-    await client.call('test-rp', null, .1)
+    await client.call('test-rp', null)
     fail('still responds')
   } catch (e) {
     if (e.code === WSE_CLIENT_ERRORS.RP_TIMEOUT) {

--- a/tests/server2client.js
+++ b/tests/server2client.js
@@ -19,4 +19,5 @@ execute('server > client', async (success, fail) => {
   })
 
   await client.connect(SECRET, { client_meta: 1 })
+
 })


### PR DESCRIPTION
- `client_id` renamed to `cid`
- `cid` are available from `conn.cid` and `conn.client.cid`
- `conn_id` was removed from the channel events.
- instead of the `client` in channel events `conn` is passed.
- access to the client via `conn.client`
- handle disconnect during `.call`